### PR TITLE
Add numRepeats and numTrials

### DIFF
--- a/+exp/inferParameters.m
+++ b/+exp/inferParameters.m
@@ -34,8 +34,9 @@ try
   szFcn = @(a)iff(ischar(a), @()size(a,1), @()size(a,2));
   sz = iff(isempty(fieldnames(parsStruct)), 1,... % if there are no paramters sz = 1
       structfun(szFcn, parsStruct)); % otherwise get number of columns
-  % add 'numRepeats' parameter, where total number of trials = 1000
   if ~isfield(parsStruct,'numRepeats')
+    % add 'numRepeats' parameter, where total number of trials = 1000 (or
+    % numTrials, available)
     if ~isfield(parsStruct,'numTrials')
       parsStruct.numRepeats = ones(1,max(sz))*floor(1000/max(sz));
     else
@@ -48,7 +49,7 @@ try
     'numRepeats must be equal to the length of other conditionals');
     if isfield(parsStruct,'numTrials')
       warning('Unused field numTrials removed');
-      parsStruct = rmfield(parsStruct,'numTrials')
+      parsStruct = rmfield(parsStruct,'numTrials');
     end
   end
   parsStruct.defFunction = expdef;

--- a/+exp/inferParameters.m
+++ b/+exp/inferParameters.m
@@ -25,7 +25,7 @@ try
   
   % Check for reserved fieldnames
   reserved = {'randomiseConditions', 'services', 'expPanelFun', ...
-    'numRepeats', 'defFunction', 'waterType', 'isPassive'};
+    'defFunction', 'waterType', 'isPassive'};
   assert(~any(ismember(fieldnames(parsStruct), reserved)), ...
     'exp:InferParameters:ReservedParameters', ...
     'The following param names are reserved:\n%s', ...
@@ -35,7 +35,22 @@ try
   sz = iff(isempty(fieldnames(parsStruct)), 1,... % if there are no paramters sz = 1
       structfun(szFcn, parsStruct)); % otherwise get number of columns
   % add 'numRepeats' parameter, where total number of trials = 1000
-  parsStruct.numRepeats = ones(1,max(sz))*floor(1000/max(sz));
+  if ~isfield(parsStruct,'numRepeats')
+    if ~isfield(parsStruct,'numTrials')
+      parsStruct.numRepeats = ones(1,max(sz))*floor(1000/max(sz));
+    else
+      parsStruct.numRepeats = ones(1,max(sz))*floor(parsStruct.numTrials/max(sz));
+    end
+  else
+    % check that struct has the right size
+    assert(all(max(size(parsStruct.numRepeats))==max(sz)),...
+    'exp:IncorrectConditionalRepeatsSize',...
+    'numRepeats must be equal to the length of other conditionals');
+    if isfield(parsStruct,'numTrials')
+      warning('Unused field numTrials removed');
+      parsStruct = rmfield(parsStruct,'numTrials')
+    end
+  end
   parsStruct.defFunction = expdef;
   parsStruct.type = 'custom';
   % Define the ExpPanel to use (automatically by name convention for now)


### PR DESCRIPTION
In an expDef you can now define an unused signal:
`
unused = p.numRepeats;
`
or
`
unused = p.numTrials;
`
In your params section, define these:
`
p.numRepeats = [10 5 1 ...]; % columns must match other conditional variables
`
or
`
p.numTrials = 150; % will be evenly distributed, i.e. p.numTrials/floor(nconditions)
`
these are then interpreted correctly by `exp.inferParameters` to generate the per-condition numbers of repeats. This also lets you set different numbers of repeats per condition (quick testing confirms this works). 